### PR TITLE
Fixes linux icon issues... maybe...

### DIFF
--- a/main.js
+++ b/main.js
@@ -19,7 +19,7 @@ function onClosed() {
 function createMainWindow() {
 	let win;
 	const windowProperties = {
-		icon: 'images/icon128.png',
+		icon: __dirname+'/images/icon128.png',
 		title: 'HuxleyFM',
 		resizable: false
 	};


### PR DESCRIPTION
I prefixed the icon with __dirname and now the icon seems to work in ubuntu 14.04. Though it seems to work now even after I reverted the change. I'm not sure why it seems to work now.
